### PR TITLE
correct method name file-namd-as-directory

### DIFF
--- a/init.el
+++ b/init.el
@@ -23,7 +23,7 @@
 
 ;;default live packs
 (let* ((live-dir (file-name-as-directory "live"))
-       (user-dir (file-namd-as-directory "user")))
+       (user-dir (file-name-as-directory "user")))
   (setq live-packs (list (concat live-dir "foundation-pack")
                          (concat live-dir "colour-pack")
                          (concat live-dir "clojure-pack")


### PR DESCRIPTION
Hi Sam,
   The function name should be file-name-as-directory
