### PR TITLE
fixed (void-symbol pack-name) bug in live-pack-dir

### DIFF
--- a/lib/live-core.el
+++ b/lib/live-core.el
@@ -44,9 +44,9 @@
 
 (defun live-pack-dir (pack)
   "Determine a pack name's absolute path"
-  (let* ((pack-name (if (symbolp pack-name)
-                        (symbol-name pack-name)
-                      pack-name))
+  (let* ((pack-name (if (symbolp pack)
+                        (symbol-name pack)
+                      pack))
          (pack-name-dir (if (file-name-absolute-p pack-name)
                             (file-name-as-directory pack-name)
                           (file-name-as-directory (concat live-packs-dir pack-name)))))


### PR DESCRIPTION
Fixed a `(void-symbol pack-name)` bug in `live-pack-dir` where `pack` (the function parameter) should have been used instead of `pack-name` in the `(let* ((pack-name ...) ...) ...)` binding.

This function seemed to only be called by the function `live-pack-dirs` and was working without error in that instance probably because of the binding of `pack-name` in the lambda within `live-pack-dirs`.

(P.S.: Sorry if this pull request got submitted twice, I thought I had already submitted it but don't see it listed in the base repo)
