### PR TITLE
Added line to startup message to help new users get past zoned-out buffer

### DIFF
--- a/init.el
+++ b/init.el
@@ -195,6 +195,8 @@
                                                                   ) "
 ;;           http://github.com/overtone/emacs-live
 ;;
+;; (Press any key to stop the madness and start the awesome!)
+;;
 ;; "                                                      (live-welcome-message) "
 
 ")))


### PR DESCRIPTION
There've been a couple of comments on the emacs-live mailing list about not knowing what to do when presented with a wacky buffer full of flickering text (I admit to being somewhat nonplussed by it myself the first time I saw it, but more in the "Whoa, I didn't know Emacs could do that!  Brilliant!" kind of way rather than the "What is this I don't even--?!" way).  I added a line to the message encouraging them to press a key; hopefully that will help make it a little more clear that it's just part of the welcome and that they won't have to do all of their Overtone/Clojure/Whatever hacking with crazy, jittery characters.
