### PR TITLE
Tweak Gandalf theme.

### DIFF
--- a/packs/dev/colour-pack/lib/gandalf.el
+++ b/packs/dev/colour-pack/lib/gandalf.el
@@ -87,7 +87,9 @@
      (rainbow-delimiters-unmatched-face ((t (:foreground "white"))))
 
      (vhl/default-face ((t (:background "grey60"))))
-     (undo-tree-visualizer-active-branch-face ((t (:foreground "deep pink" :background "grey40"))))
+      (undo-tree-visualizer-active-branch-face ((t (:foreground "deep pink" :background "grey40"))))
+
+      (markdown-link-face ((t (:background "#FBDE2D"))))
      )
    ))
 

--- a/packs/live/colour-pack/lib/gandalf.el
+++ b/packs/live/colour-pack/lib/gandalf.el
@@ -87,7 +87,9 @@
      (rainbow-delimiters-unmatched-face ((t (:foreground "white"))))
 
      (vhl/default-face ((t (:background "grey60"))))
-     (undo-tree-visualizer-active-branch-face ((t (:foreground "deep pink" :background "grey40"))))
+      (undo-tree-visualizer-active-branch-face ((t (:foreground "deep pink" :background "grey40"))))
+
+      (markdown-link-face ((t (:background "#FBDE2D"))))
      )
    ))
 


### PR DESCRIPTION
The foreground yellow Markdown link face inherited from Cyberpunk
is unreadable on a white background.

The suggestion here is just to make it a background instead of foreground color -- though we could also pick a new alternative color?
