### PR TITLE
add info.el to user-template-pack

### DIFF
--- a/packs/template/user-template-pack/README.md
+++ b/packs/template/user-template-pack/README.md
@@ -8,6 +8,13 @@ Use the file `init.el` for your own configuration elisp. If this starts
 getting unweildy then you might want to break out the config into
 separate files which you can store in the config directory.
 
+### info.el
+
+Set the pack's description in `info.el`, e.g.
+
+    (live-pack-version "1.0")                   ;; required
+    (live-pack-description "Custom additions")  ;; optional
+
 ### config
 
 Files placed in the `config` dir may then be referenced and pulled into

--- a/packs/template/user-template-pack/info.el
+++ b/packs/template/user-template-pack/info.el
@@ -1,0 +1,1 @@
+(live-pack-version "1.0")


### PR DESCRIPTION
release/1.0-BETA-19 of emacs-live requires that custom packs set their version e.g.

``` clojure
(live-pack-version "1.0")
```

This adds that in an `info.el` file and upgrades the README as well.
