### PR TITLE
Allow user to define `live-root-dir'.

### DIFF
--- a/init.el
+++ b/init.el
@@ -94,8 +94,11 @@
       (error (concat "Oops - your emacs isn't supported. Emacs Live only works on Emacs 24+ and you're running version: " emacs-version ". Please upgrade your Emacs and try again, or define ~/.emacs-old.el for a fallback")))))
 
 (when live-supported-emacsp
-;; Store live base dirs
-(setq live-root-dir user-emacs-directory)
+;; Store live base dirs, but respect user's choice of `live-root-dir'
+;; when provided.
+(setq live-root-dir (if (boundp 'live-root-dir)
+                        (file-name-as-directory live-root-dir)
+                      user-emacs-directory))
 
 (setq
  live-tmp-dir      (file-name-as-directory (concat live-root-dir "tmp"))


### PR DESCRIPTION
Hey Sam, I hope everything is in order. (This is my very first time doing this (a pull request).)

BTW, I don't have any tests to give you with this.  I can only proffer a bald assertion that it works for me just fine, as I outlined in the forum message.  Is this the best way to update the code to have a user-defined `live-root-dir`?  I don't know.

Here's something to think about.  Will this change break any other script/code?  (Or more precisely, will moving the Emacs Live root to something other than `~/.emacs.d` break any extant code?)  A candidate for breakage, for instance, might be the script `packs/update-live-packs` which has hardcoded paths, like `~/.emacs.d/packs/live`.  (I went to the root of emacs-live and executed a `grep -R '~/.emacs.d' *` to reveal this.  There are many more grep hits, but most if not all may not be problems at all.)

Thanks! —Rick
