### PR TITLE
Switch to ruby-mode on .rake, .gemspec and Gemfile

### DIFF
--- a/packs/live/lang-pack/config/ruby-conf.el
+++ b/packs/live/lang-pack/config/ruby-conf.el
@@ -5,6 +5,9 @@
 
 (add-to-list 'auto-mode-alist '("\\.rb$" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Rakefile$" . ruby-mode))
+(add-to-list 'auto-mode-alist '("\\.rake$" . ruby-mode))
+(add-to-list 'auto-mode-alist '("Gemfile$" . ruby-mode))
+(add-to-list 'auto-mode-alist '("\\.gemspec$" . ruby-mode))
 
 (defun ruby-interpolate ()
   "In a double quoted string, interpolate."


### PR DESCRIPTION
These are all files that contain Ruby code so it makes sense to switch to ruby-mode when opening them.

Please consider merging.
