### PR TITLE
Use optional env variable EMACS_LIVE_DIR to set emacs-user-directory.

### DIFF
--- a/init.el
+++ b/init.el
@@ -93,6 +93,10 @@
       (load-file old-file)
       (error (concat "Oops - your emacs isn't supported. Emacs Live only works on Emacs 24+ and you're running version: " emacs-version ". Please upgrade your Emacs and try again, or define ~/.emacs-old.el for a fallback")))))
 
+(let ((emacs-live-directory (getenv "EMACS_LIVE_DIR")))
+  (when emacs-live-directory
+    (setq user-emacs-directory emacs-live-directory)))
+
 (when live-supported-emacsp
 ;; Store live base dirs, but respect user's choice of `live-root-dir'
 ;; when provided.


### PR DESCRIPTION
Hi Sam,

My use case is that I'd like "emacs" to just be the vanilla emacs, but then, still be able to use emacs-live when I want to. 

I use this to have Emacs Live configured under a special user, say,
overtone. Then, from bash, I can run Emacs-Live as follows:
$ export EMACS_LIVE_DIR=~/../overtone/.emacs.d
$ emacs -u overtone

I am not sure whether this is useful for others too. What do you think?

Thanks. ~n
