### PR TITLE
Function for setting a default darwin font.

### DIFF
--- a/packs/dev/foundation-pack/config/cosmetic.el
+++ b/packs/dev/foundation-pack/config/cosmetic.el
@@ -16,9 +16,20 @@
 ;remove bells
 (setq ring-bell-function 'ignore)
 
-(cond
- ((and (window-system) (eq system-type 'darwin))
-  (add-to-list 'default-frame-alist '(font . "Menlo-12"))))
+;; default darwin font
+(require 'cl)
+
+(defun live-set-default-darwin-font (font-string)
+  (interactive "MNew darwin default font: ")
+  (setq default-frame-alist
+        (remove-if (lambda (x)
+                     (eq 'font (car x)))
+                   default-frame-alist))
+  (cond
+   ((and (window-system) (eq system-type 'darwin))
+    (add-to-list 'default-frame-alist (cons 'font font-string)))))
+
+(live-set-default-darwin-font "Menlo-12")
 
 ;; make fringe smaller
 (if (fboundp 'fringe-mode)


### PR DESCRIPTION
As I am also someone who likes to use Courier when I'm using Emacs, this summer @cassiel showed me some functions he put in his `.emacs-live.el` to in one command change the theme (to either gandalf or cyberpunk depending on the function) and set the font to Courier. I don't remember exactly what the situation was, but if I recall there was some issue with the way Menlo was being set as the default darwin font that was making it difficult for us to change it globally during setup.

I added this code to define a function for changing the default darwin font. It works being called from `custom-configuration.el` (but obviously not `.emacs-live.el` since the function wouldn't be loaded yet) or it can be called interactively.

Don't worry, Menlo 12 is still the default.
