### PR TITLE
Added live-set-default-font

### DIFF
--- a/packs/dev/foundation-pack/config/cosmetic.el
+++ b/packs/dev/foundation-pack/config/cosmetic.el
@@ -16,18 +16,27 @@
 ;remove bells
 (setq ring-bell-function 'ignore)
 
-;; default darwin font
+;; font setitng functions
 (require 'cl)
 
-(defun live-set-default-darwin-font (font-string)
-  (interactive "MNew darwin default font: ")
+(defun live-set-default-font (font-string)
+  "Sets the default font and sets all frames to the same font trying to maintain window resolution. Only changes font if window system is not a basic terminal."
+  (interactive "MNew emacs live default font: ")
   (setq default-frame-alist
         (remove-if (lambda (x)
                      (eq 'font (car x)))
                    default-frame-alist))
   (cond
-   ((and (window-system) (eq system-type 'darwin))
-    (add-to-list 'default-frame-alist (cons 'font font-string)))))
+   ((member (window-system) '(x w32 ns))
+    (add-to-list 'default-frame-alist (cons 'font font-string))
+    (set-default-font font-string t t))))
+
+(defun live-set-default-darwin-font (font-string)
+  "Sets the default font and sets all frames to the same font trying to maintain window resolution. Only changes font if system-type is darwin in a window system."
+  (interactive "MNew darwin default font: ")
+  (cond
+   ((eq system-type 'darwin)
+    (live-set-default-font font-string))))
 
 (live-set-default-darwin-font "Menlo-12")
 


### PR DESCRIPTION
Updated the previous font submitting code with doc strings and adding ability to set default fonts on systems other than darwin.
- live-set-default-font changes the default font and updates all windows
  if emacs is running in XWindows, Win32, or NS drawing systems.
- live-set-default-darwin-font calls live-set-default-font only if running
  in drawin.
- Menlo is only set on drawin.

Where would you like me to put this in your doc pages? Under the FAQ?
