### PR TITLE
Fix setting custom file.

### DIFF
--- a/init.el
+++ b/init.el
@@ -210,7 +210,7 @@
 (if (not live-disable-zone)
     (add-hook 'term-setup-hook 'zone))
 
-(if (not (boundp 'custom-file))
+(if (not custom-file)
     (setq custom-file (concat live-custom-dir "custom-configuration.el")))
 (when (file-exists-p custom-file)
   (load custom-file))


### PR DESCRIPTION
The variable custom file is already set to nil in cus-edit.el, so it
does not make sense to check with boundp. Better to check if it is nil.
