### PR TITLE
Fix sudo-edit function

### DIFF
--- a/packs/dev/foundation-pack/config/tramp-conf.el
+++ b/packs/dev/foundation-pack/config/tramp-conf.el
@@ -4,7 +4,7 @@
 (setq tramp-bkup-backup-directory-info  nil)
 
 (defun sudo-edit (&optional arg)
-  (interactive "p")
+  (interactive "P")
   (if (or arg (not buffer-file-name))
       (find-file (concat "/sudo:root@localhost:" (ido-read-file-name "File: ")))
     (find-alternate-file (concat "/sudo:root@localhost:" buffer-file-name))))


### PR DESCRIPTION
When using (interactive "p"), arg is turn into value 1 when arg is nil
and therefore condition in if form is always true. With raw
version, (interactive "P"), arg remains nil if nil.
