### PR TITLE
Fix typito in `live-current-pack-dir` docstring.

### DIFF
--- a/lib/live-core.el
+++ b/lib/live-core.el
@@ -1,6 +1,6 @@
 (require 'cl)
 
-(defvar live-current-pack-dir nil "The directory of the pack bein currently loaded")
+(defvar live-current-pack-dir nil "The directory of the pack being currently loaded")
 (defvar live-current-pack-version nil "The version string of the pack being currently loaded")
 (defvar live-current-pack-name nil "The name of the pack being currently loaded")
 (defvar live-current-pack-description nil "The description of the pack being currently loaded")


### PR DESCRIPTION
**typito** _n._ - a tiny typo, often trivial.

> If users of open-source libraries correct **typitos** and other
> little errors themselves, the creators and maintainers are free
> to spend their creative energies elsewhere.
