### PR TITLE
Switch to Ruby mode when opening .rake, Gemfile or .gemspec files

### DIFF
--- a/packs/live/lang-pack/config/ruby-conf.el
+++ b/packs/live/lang-pack/config/ruby-conf.el
@@ -5,6 +5,9 @@
 
 (add-to-list 'auto-mode-alist '("\\.rb$" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Rakefile$" . ruby-mode))
+(add-to-list 'auto-mode-alist '("\\.rake$" . ruby-mode))
+(add-to-list 'auto-mode-alist '("Gemfile$" . ruby-mode))
+(add-to-list 'auto-mode-alist '("\\.gemspec$" . ruby-mode))
 
 (defun ruby-interpolate ()
   "In a double quoted string, interpolate."


### PR DESCRIPTION
Use ruby-mode when editing rake or gem files.

This change was committed a while ago (7fe8671) but appears to have been backed out in revision 1e508ca. I get the impression that it wasn't backed out on purpose because the changelog mentions adding it.
