### PR TITLE
cycle through colls

### DIFF
--- a/packs/dev/clojure-pack/config/clojure-conf.el
+++ b/packs/dev/clojure-pack/config/clojure-conf.el
@@ -75,7 +75,7 @@
 
 (define-key clojure-mode-map (kbd "C-:") 'live-toggle-clj-keyword-string)
 
-(defun live-toggle-clj-coll ()
+(defun live-cycle-clj-coll ()
   "convert the coll at (point) from (x) -> {x} -> [x] -> (x) recur"
   (interactive)
   (let* ((original-point (point)))
@@ -95,4 +95,4 @@
       (message "beginning of file reached, this was probably a mistake.")))
     (goto-char original-point)))
 
-(define-key clojure-mode-map (kbd "C->") 'live-toggle-clj-coll)
+(define-key clojure-mode-map (kbd "C->") 'live-cycle-clj-coll)


### PR DESCRIPTION
I find this helpful when converting something from a list -> vec or a vec <-> hash-map

it could be smarter (possibly) by looking for the tick before a list, or the # before the { (thus it's a set), but I felt like that's very easily handled by the user and a single keystroke. Better to stick to what definitely works.
