### PR TITLE
Set pbpaste to run locally even when editing a TRAMP buffer

### DIFF
--- a/packs/dev/foundation-pack/config/osx.el
+++ b/packs/dev/foundation-pack/config/osx.el
@@ -6,7 +6,9 @@
 ;; Make cut and paste work with the OS X clipboard
 
 (defun live-copy-from-osx ()
-  (shell-command-to-string "pbpaste"))
+  (let ((tramp-mode nil)
+        (default-directory "~"))
+       (shell-command-to-string "pbpaste")))
 
 (defun live-paste-to-osx (text &optional push)
   (let ((process-connection-type nil))


### PR DESCRIPTION
Code stolen from [pbcopy.el](https://github.com/jeffgran/pbcopy.el/commit/65245817c5112d70bf9b4847e5055f785c1d3e24)

I'm not sure what's the difference between the dev/ and live/ directories, should I apply this change there as well?
