### PR TITLE
Specify Emacs 24.3 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ in battle against the evil friction of poor text editor workflows.
     "Power of the horse, full force!"
                  The Space Stallions.
 
-### Requires Emacs 24
+### Requires Emacs 24.3
 
-Emacs Live is only compatible with Emacs 24 and above.
+Emacs Live is only compatible with Emacs 24.3 and above.
 
 ### Easy Install
 


### PR DESCRIPTION
Make the 24.3 dependency explicit as this affects Debian/Ubuntu/Mint users, since official emacs24 is at 24.1.1.
