### PR TITLE
Ensure .emacs.d is a git repository

### DIFF
--- a/installer/install-emacs-live.sh
+++ b/installer/install-emacs-live.sh
@@ -154,7 +154,7 @@ To revert back to your old Emacs configs simply:
     fi
 
     mkdir ~/.emacs.d
-    cp -R $tmp_dir/overtone-emacs-live/* ~/.emacs.d
+    cp -R $tmp_dir/overtone-emacs-live/. ~/.emacs.d
     echo $(tput setaf 4)"Personal Pack"
     echo "-------------"$(tput sgr0)
     echo ""


### PR DESCRIPTION
The current copy operation omits hidden files and folders which means that `.git` is not copied and `.emacs.d` is not a git respository. This makes it much more difficult to update emacs-live later.

This change ensures that the entire contents of `$tmp_dir/overtone-emacs-live` is copied to `~/.emacs.d`, including `.git`.
