### PR TITLE
doc-string face changed with font-lock-doc-face in cyberpunk theme

### DIFF
--- a/packs/stable/colour-pack/lib/cyberpunk.el
+++ b/packs/stable/colour-pack/lib/cyberpunk.el
@@ -31,7 +31,7 @@
      (font-lock-builtin-face ((t (:foreground "#FF6400"))))
      (font-lock-comment-face ((t (:italic t :foreground "#8B8989"))))
      (font-lock-constant-face ((t (:foreground "#4c83ff"))))
-     (font-lock-doc-string-face ((t (:foreground "DarkOrange"))))
+     (font-lock-doc-face ((t (:italic t :foreground "DarkOrange"))))
      (font-lock-function-name-face ((t (:foreground "deep pink"))))
      (font-lock-keyword-face ((t (:foreground "#FBDE2D"))))
      (font-lock-preprocessor-face ((t (:foreground "gray57"))))


### PR DESCRIPTION
The doc-string face for Clojure / elisp was changed using `font-lock-doc-face` rather than `font-lock-doc-string-face` in the cyberpunk theme.  This gives the clojure / elisp doc strings their own face characteristics (italic DarkOrange).

`font-lock-doc-string-face` does not change the face characteristics of doc-string for elisp or clojure.  However, changing the theme to use `font-lock-doc-face` does change the characteristics of the doc-string face.  This change does not affect comments, strings or help text.

Here is a screenshot of the change:
 
![emacs-live-theme-cyberpunk-doc-string-face-fix](https://cloud.githubusercontent.com/assets/250870/5939096/bf0f84b8-a6f8-11e4-8990-38e073ecec84.png)

If this is not the correct way to fix the theme, please point me in the right direction.