### PR TITLE
query replace highlight - darker shade of gray - cyberpunk theme

### DIFF
--- a/packs/stable/colour-pack/lib/cyberpunk.el
+++ b/packs/stable/colour-pack/lib/cyberpunk.el
@@ -55,7 +55,7 @@
      (isearch-fail ((t (:background "red4"))))
      (lazy-highlight ((t (:background "yellow" :foreground "black"))))
      (next-error ((t (:background "deep pink" :foreground "black"))))
-     (query-replace ((t (:background "gray10"))))
+     (query-replace ((t (:background "gray42"))))
      (Highline-face ((t (:background "SeaGreen"))))
      (hl-line ((t (:background "gray10"))))
      (italic ((t (nil))))


### PR DESCRIPTION
Issue #184 fix - changed the colour value from `grey10` to `grey42` to give a darker background when highlighting

Here is a screenshot of the proposed change

![emacs-live-query-replace-fix](https://cloud.githubusercontent.com/assets/250870/5939783/91bbc67e-a6fe-11e4-95bc-d56ac30897b4.png)
