### PR TITLE
fix for cider-macroexpansion #167

### DIFF
--- a/packs/stable/clojure-pack/config/cider-conf.el
+++ b/packs/stable/clojure-pack/config/cider-conf.el
@@ -1,5 +1,6 @@
 (live-add-pack-lib "cider")
 (require 'cider)
+(require 'cider-macroexpansion)
 
 (defun live-windows-hide-eol ()
  "Do not show ^M in files containing mixed UNIX and DOS line endings."


### PR DESCRIPTION
cider-macroexpansion doesn't work on emacs-live as the `require` is missing