### PR TITLE
color-theme-gandalf: colors improvement for magit

### DIFF
--- a/packs/stable/colour-pack/lib/gandalf.el
+++ b/packs/stable/colour-pack/lib/gandalf.el
@@ -78,6 +78,12 @@
      (magit-diff-hunk-header ((t (:foreground "orange"))))
      (magit-branch ((t (:foreground "DarkGoldenRod"))))
 
+     (git-commit-summary-face ((t (:foreground "black" :background nil))))
+     (git-commit-comment-heading-face ((t (:background nil :foreground "deep pink"))))
+     (git-commit-summary-face ((t (:background nil :foreground "white"))))
+     (git-commit-branch-face ((t (:background nil :foreground "#FF6400"))))
+     (git-commit-nonempty-second-line-face ((t (:background nil :foreground "#FBDE2D"))))
+
      (eval-sexp-fu-flash ((t (:background "DeepPink3" :foreground "black"))))
      (cider-error-highlight-face ((t (:background "color-52"))))
 

--- a/packs/stable/colour-pack/lib/gandalf.el
+++ b/packs/stable/colour-pack/lib/gandalf.el
@@ -70,7 +70,8 @@
      (flx-highlight-face ((t (:foreground "black" :background "deep pink"))))
 
      ;; magit
-     (magit-item-highlight ((t (:background "gray15"))))
+     (magit-item-highlight ((t (:background "gray95"))))
+     (diff-file-header ((t (:background "gray90"))))
      (magit-diff-add ((t (:foreground "chartreuse3"))))
      (magit-diff-del ((t (:foreground "violet red"))))
      (magit-section-type ((t (:foreground "deep pink"))))


### PR DESCRIPTION
Prior to that most of those colors were too cyberpunk-ish.

![screen shot 2015-05-07 at 5 00 10 pm](https://cloud.githubusercontent.com/assets/66214/7516928/d50463f8-f4da-11e4-9b1c-ca7d8f449ed4.png)
![screen shot 2015-05-07 at 4 53 27 pm](https://cloud.githubusercontent.com/assets/66214/7516938/dcd2e30c-f4da-11e4-92e5-41ddee4188fe.png)
