### PR TITLE
Correctly preserve original `basic-save-buffer`.

### DIFF
--- a/packs/dev/foundation-pack/config/monkey-patch.el
+++ b/packs/dev/foundation-pack/config/monkey-patch.el
@@ -101,5 +101,5 @@ Before and after saving the buffer, this function runs
       (message "(No changes need to be saved)"))))
 
 
-(defalias 'live-mp-orig-basic-save-buffer 'basic-save-buffer)
+(defalias 'live-mp-orig-basic-save-buffer (symbol-function 'basic-save-buffer))
 (defalias 'basic-save-buffer 'live-mp-new-basic-save-buffer)


### PR DESCRIPTION
*monkey-patch.el* was defining an alias `live-mp-orig-basic-save-buffer`
 which was bound to the symbol `basic-save-buffer`. After redefining
 `basic-save-buffer` with the call `(defalias 'basic-save-buffer
 'live-mp-new-basic-save-buffer)`, both `basic-save-buffer` and
 `live-mp-orig-basic-save-buffer` were both bound to the function
 `live-mp-new-basic-save-buffer`.

 Instead, the backup alias should be bound to the function directly, not
 the symbol.