### PR TITLE
Fixed `org-odt-data-dir`.

### DIFF
--- a/packs/dev/org-pack/lib/org-loaddefs.el
+++ b/packs/dev/org-pack/lib/org-loaddefs.el
@@ -1783,8 +1783,8 @@ The Git version of org-mode.
 
 \(fn)" nil nil)
 
-(defvar org-odt-data-dir "/usr/share/emacs/etc/org" "\
-The location of ODT styles.")
+(defvar org-odt-data-dir (expand-file-name "./org-mode/etc" (live-pack-lib-dir))
+  "The location of ODT styles.")
 
 ;;;***
 

--- a/packs/dev/org-pack/lib/org-version.el
+++ b/packs/dev/org-pack/lib/org-version.el
@@ -13,12 +13,9 @@
   Inserted by installing org-mode or when a release is made."
    (let ((org-git-version "release_8.0-1-g5ef07d"))
      org-git-version))
-;;;###autoload
-(defvar org-odt-data-dir "/usr/share/emacs/etc/org"
-  "The location of ODT styles.")
-
+
 (provide 'org-version)
-
+
 ;; Local Variables:
 ;; version-control: never
 ;; no-byte-compile: t


### PR DESCRIPTION
`org-odt-data-dir` was being set to an abosulte path for *org-mode*
included with emacs installed in /usr/share.

Updated `org-odt-dat-dir` to point to the *org-mode* pack.