### PR TITLE
Fixes #210: Missing edn submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -158,3 +158,6 @@
 [submodule "packs/dev/clojure-pack/vendor/submodules/rainbow-delimiters"]
 	path = packs/dev/clojure-pack/vendor/submodules/rainbow-delimiters
 	url = https://github.com/Fanael/rainbow-delimiters
+[submodule "packs/dev/clojure-pack/vendor/submodules/edn"]
+	path = packs/dev/clojure-pack/vendor/submodules/edn
+	url = https://github.com/expez/edn.el.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -152,9 +152,6 @@
 [submodule "packs/dev/clojure-pack/vendor/submodules/ac-cider"]
 	path = packs/dev/clojure-pack/vendor/submodules/ac-cider
 	url = git://github.com/clojure-emacs/ac-cider.git
-[submodule "packs/dev/clojure-pack/vendor/submodules/edn"]
-	path = packs/dev/clojure-pack/vendor/submodules/edn
-	url = git://github.com/expez/edn.el.git
 [submodule "packs/dev/clojure-pack/vendor/submodules/cider-eval-sexp-fu"]
 	path = packs/dev/clojure-pack/vendor/submodules/cider-eval-sexp-fu
 	url = git://github.com/clojure-emacs/cider-eval-sexp-fu.git


### PR DESCRIPTION
I think this Fixes #210 where some users were unable to initialize and update the edn.el submodule.

I need some other users to try it out to make sure this is a real fix, but removing the submodule, committing, adding the submodule, and committing again seemed to fix it.