### PR TITLE
create a profile for nrepl

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,20 @@ If you wish to hack with Clojure projects such as
 [Leiningen 2](https://github.com/technomancy/leiningen/wiki/Upgrading)
 and you're ready to roll.
 
-Simply start a repl in a Clojure project with `lein2 repl` and connect
-to it from Emacs with `M-x cider` (supplying the correct port) for full
-Emacs REPL/autocompletion joy.
+Make sure you create a profile in `~/.lein/profiles.clj`. It should
+contain the following:
+
+```
+{:user {
+ :plugins [[cider/cider-nrepl "0.9.1"]
+           [refactor-nrepl "1.1.0"]]
+ :dependencies [[org.clojure/tools.nrepl "0.2.7"]]
+ }}
+```
+
+Now you're ready to start a repl in a Clojure project with `lein repl`
+and connect to it from Emacs with `M-x cider-connect` (supplying the
+host and the correct port) for full Emacs REPL/autocompletion joy.
 
 ### Screenshots
 


### PR DESCRIPTION
Without such a profile adding cider/cider-nrepl and friends, M-x
cider-connect will complain: "WARNING: CIDER requires nREPL 0.2.7 (or
newer) to work properly"