### PR TITLE
Auto-compile module needed some fix

### DIFF
--- a/packs/dev/foundation-pack/config/auto-compile-conf.el
+++ b/packs/dev/foundation-pack/config/auto-compile-conf.el
@@ -1,5 +1,8 @@
+(setq load-prefer-newer t)
+(live-add-pack-lib "dash")
 (live-add-pack-lib "packed")
 (live-add-pack-lib "auto-compile")
+
 (require 'auto-compile)
 
 (auto-compile-on-load-mode 1)


### PR DESCRIPTION
Fix for auto-compile, it now needs dash in the load path and add load--prefer-newer as suggested in its [README](https://github.com/tarsius/auto-compile#setup)