### PR TITLE
Bumps required emacs version to 24.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <img src="http://github.com/downloads/overtone/emacs-live/emacs-live.png" />
 
 <!--
@@ -53,9 +54,9 @@ in battle against the evil friction of poor text editor workflows.
     "Power of the horse, full force!"
                  The Space Stallions.
 
-### Requires Emacs 24.3
+### Requires Emacs 24.4
 
-Emacs Live is only compatible with Emacs 24.3 and above.
+Emacs Live is only compatible with Emacs 24.4 and above.
 
 ### Easy Install
 

--- a/init.el
+++ b/init.el
@@ -77,7 +77,7 @@
 
 (setq live-supported-emacsp t)
 
-(when (version< emacs-version "24.3")
+(when (version< emacs-version "24.4")
   (setq live-supported-emacsp nil)
   (setq initial-scratch-message (concat "
 ;;                _.-^^---....,,--
@@ -92,7 +92,7 @@
 ;;                     | ;  :|
 ;;            _____.,-#%&$@%#&#~,._____
 ;;
-;; I'm sorry, Emacs Live is only supported on Emacs 24.3+.
+;; I'm sorry, Emacs Live is only supported on Emacs 24.4+.
 ;;
 ;; You are running: " emacs-version "
 ;;
@@ -110,7 +110,7 @@
   (let* ((old-file (concat (file-name-as-directory "~") ".emacs-old.el")))
     (if (file-exists-p old-file)
       (load-file old-file)
-      (error (concat "Oops - your emacs isn't supported. Emacs Live only works on Emacs 24.3+ and you're running version: " emacs-version ". Please upgrade your Emacs and try again, or define ~/.emacs-old.el for a fallback")))))
+      (error (concat "Oops - your emacs isn't supported. Emacs Live only works on Emacs 24.4+ and you're running version: " emacs-version ". Please upgrade your Emacs and try again, or define ~/.emacs-old.el for a fallback")))))
 
 (let ((emacs-live-directory (getenv "EMACS_LIVE_DIR")))
   (when emacs-live-directory


### PR DESCRIPTION
GNU Emacs 24.3 is missing function string-suffix-p and this
causes emacs-live to fail at start. This function is added
in 24.4

see magit/magit#1500

this might be cause of confusion at #217