### PR TITLE
Relocate ido.last to live-tmp-dir

### DIFF
--- a/packs/stable/foundation-pack/config/ido-conf.el
+++ b/packs/stable/foundation-pack/config/ido-conf.el
@@ -9,7 +9,8 @@
       ido-create-new-buffer 'always
       ido-max-prospects 10
       ido-default-file-method 'selected-window
-      ido-everywhere 1)
+      ido-everywhere 1
+      ido-save-directory-list-file (concat live-tmp-dir "ido.last"))
 
 (icomplete-mode 1)
 


### PR DESCRIPTION
This is the updated version of [earlier pull request 150](https://github.com/overtone/emacs-live/pull/150) which is almost a year old. For some reason on my machine, I won't be able to quit emacs if I have modified some files and just like to quit without saving them.