### PR TITLE
Updated .gitignore (ignoring ido.last and smex-items)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ tramp
 tmp/*
 .smex-items
 swank/*
+ido.last
+smex-items


### PR DESCRIPTION
Ignoring:
- ido.last
- smex-items

I have emacs-live installed as a submodule with the rest of my custom packs and configuration. My emacs-live submodule was always dirty because of these directories. Could we ignore them? Or do you commit these to your own branches?