### PR TITLE
Remove obsolete `cider--region-for-defun-at-point` call

### DIFF
--- a/packs/dev/clojure-pack/config/highlight-flash-conf.el
+++ b/packs/dev/clojure-pack/config/highlight-flash-conf.el
@@ -91,11 +91,6 @@
   (define-eval-sexp-fu-flash-command cider-pprint-eval-last-sexp
     (eval-sexp-fu-flash (live-bounds-of-cider-last-sexp)))
 
-  (define-eval-sexp-fu-flash-command cider-eval-defun-at-point
-    (eval-sexp-fu-flash (let ((bounds (cider--region-for-defun-at-point)))
-                          (cons (first bounds) (second bounds)))))
-
-
   (progn
     ;; Defines:
     ;; `eval-sexp-fu-cider-sexp-inner-list',


### PR DESCRIPTION
This assignment call in hightlight-flash-conf.el breaks the `C-M-x` keybinding for cider-eval-defun-at-point