### PR TITLE
Disable bad nrepl-connected-hook

### DIFF
--- a/packs/stable/clojure-pack/config/cider-conf.el
+++ b/packs/stable/clojure-pack/config/cider-conf.el
@@ -41,7 +41,7 @@
 ;; (defun live-nrepl-set-print-length ()
 ;;   (nrepl-send-string-sync "(set! *print-length* 100)" "clojure.core"))
 
-(add-hook 'nrepl-connected-hook 'live-nrepl-set-print-length)
+;; (add-hook 'nrepl-connected-hook 'live-nrepl-set-print-length)
 
 (setq nrepl-port "4555")
 


### PR DESCRIPTION
Since `live-nrepl-set-print-length` is disabled (and `nrepl-send-string-sync` isn't defined anyway), you need to comment out the `nrepl-connected-hook`.