### PR TITLE
Restore C-M-x / C-c C-c behavior

### DIFF
--- a/packs/dev/clojure-pack/config/highlight-flash-conf.el
+++ b/packs/dev/clojure-pack/config/highlight-flash-conf.el
@@ -91,6 +91,8 @@
   (define-eval-sexp-fu-flash-command cider-pprint-eval-last-sexp
     (eval-sexp-fu-flash (live-bounds-of-cider-last-sexp)))
 
+  (define-eval-sexp-fu-flash-command cider-eval-defun-at-point
+    (eval-sexp-fu-flash (live-bounds-of-defun)))
   (progn
     ;; Defines:
     ;; `eval-sexp-fu-cider-sexp-inner-list',


### PR DESCRIPTION
When you merged #240 (to remove the call to
cider--region-for-defun-at-point), it also removed
cider-eval-defun-at-point which broke these key bindings. CIDER code
seems to have been update to use (cider-defun-at-point 'bounds) but
since you already seem to have a function that gets the defun bounds, I
used that instead: (live-bounds-of-defun)
