### PR TITLE
Set correct org-odt-data-dir

### DIFF
--- a/packs/dev/org-pack/config/org-mode-config.el
+++ b/packs/dev/org-pack/config/org-mode-config.el
@@ -3,7 +3,8 @@
 (live-add-pack-lib "org-mode/lisp")
 (live-add-pack-lib "org-mode/contrib/lisp")
 
-
+;; set ODT data directory to emacs-live's org-mode
+(setq org-odt-data-dir (expand-file-name "./org-mode/etc" (live-pack-lib-dir)))
 
 ;; Fix conflicts (http://orgmode.org/org.html#Conflicts)
 


### PR DESCRIPTION
Updated fix for #202 

* * *

The variable org-odt-data-dir is defined in org-loaddefs.el and
org-version.el, which are created when running make or make autoloads for
org-mode.

Emacs-live bundles its own org-mode, versus using an org-mode from the host
Emacs application.  The default for org-odt-data-dir is a path to
an org-mode bundled with Emacs installed in /usr/share, but should point
to the org-mode included with Emacs-live.

Configuration for org-mode has been updated to set org-odt-data-dir based on
the location of Emacs-live after loading org-loaddefs.el and org-version.el.