### PR TITLE
Fix linum area when text is increased (EmacsWiki)

### DIFF
--- a/lib/live-core.el
+++ b/lib/live-core.el
@@ -273,3 +273,15 @@ children of DIRECTORY."
     (with-current-buffer buf
       (write-file fname)
       (auto-save-mode 1))))
+
+;; From https://www.emacswiki.org/emacs/LineNumbers#toc14
+(defun live-linum-update-window-scale-fix (win)
+  "fix linum for scaled text"
+  (set-window-margins win
+                      (ceiling (* (if (boundp 'text-scale-mode-step)
+                                      (expt text-scale-mode-step
+                                            text-scale-mode-amount) 1)
+                                  (if (car (window-margins))
+                                      (car (window-margins)) 1)
+                                  ))))
+(advice-add #'linum-update-window :after #'linum-update-window-scale-fix)


### PR DESCRIPTION
I hope this is the right place where to put these kind of fixes, I can move it if needed.

It was take from here: https://www.emacswiki.org/emacs/LineNumbers#toc14